### PR TITLE
feat: change measurementVariable

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,5 +12,6 @@ export * from './core/Range';
 export * from './core/Value';
 
 export * from './measurements/common/MeasurementXY';
+export * from './measurements/common/MeasurementVariables';
 export * from './measurements/common/MeasurementXYVariables';
 export * from './measurements/common/MeasurementVariable';

--- a/src/measurements/common/MeasurementVariable.d.ts
+++ b/src/measurements/common/MeasurementVariable.d.ts
@@ -1,11 +1,13 @@
 import { DoubleArray } from '../../core/DoubleArray';
 import { OneLetter } from '../../core/OneLetter';
 
+
+
 /**
  * Describe a variable that can only contains as data an array of number
  */
 export interface MeasurementVariable<
-  DataType extends DoubleArray = DoubleArray,
+  DataType = DoubleArray,
 > {
   /**
    * Unit of the data in the column
@@ -26,11 +28,13 @@ export interface MeasurementVariable<
    */
   data: DataType;
   /** One letter that allows to define the variable */
-  symbol?: OneLetter;
+  symbol?: string;
   /** If defined contain the minimal value of the data */
   min?: number;
   /** If defined contain the maximal value of the data */
   max?: number;
   /** If defined indicates (true or false) if the data series is monotone  */
   isMonotone?: boolean;
+  /** If defined indicates the number of times to multiply the data */
+  factor?: number;
 }

--- a/src/measurements/common/MeasurementVariables.d.ts
+++ b/src/measurements/common/MeasurementVariables.d.ts
@@ -1,0 +1,30 @@
+import { MeasurementVariable } from './MeasurementVariable';
+
+export interface MeasurementVariables<MeasurementVariableType = MeasurementVariable> {
+  a?: MeasurementVariableType;
+  b?: MeasurementVariableType;
+  c?: MeasurementVariableType;
+  d?: MeasurementVariableType;
+  e?: MeasurementVariableType;
+  f?: MeasurementVariableType;
+  g?: MeasurementVariableType;
+  h?: MeasurementVariableType;
+  i?: MeasurementVariableType;
+  j?: MeasurementVariableType;
+  k?: MeasurementVariableType;
+  l?: MeasurementVariableType;
+  m?: MeasurementVariableType;
+  n?: MeasurementVariableType;
+  o?: MeasurementVariableType;
+  p?: MeasurementVariableType;
+  q?: MeasurementVariableType;
+  r?: MeasurementVariableType;
+  s?: MeasurementVariableType;
+  t?: MeasurementVariableType;
+  u?: MeasurementVariableType;
+  v?: MeasurementVariableType;
+  w?: MeasurementVariableType;
+  x: MeasurementVariableType;
+  y: MeasurementVariableType;
+  z?: MeasurementVariableType;
+}


### PR DESCRIPTION
add factor property
change type of symbol property to string
DataType does not extends DoubleArray type
Default type for DataType is DoubleArray