### PR TITLE
docs: generate typedocs

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -7,14 +7,14 @@ on:
 
 env:
   NODE_VERSION: 16.x
-  ENTRY_FILE: 'src/index.ts'
+  ENTRY_FILE: 'cheminfoType.d.ts'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Install dependencies


### PR DESCRIPTION
It seems the docs may not be generated just because the entry point should be `cheminfoTypes.d.ts`. I updated that and the workflow versions (not sure whether it will run as I can't test.)

Wouldn't also everything related to JSON be gone and just have one typedoc, that can also generate examples in the docs? @lpatiny  in that case /json, the action and commands could be cleaned up.