### PR TITLE
fix: allow all NumberArray in DataXY

### DIFF
--- a/cheminfoTypes.test-d.ts
+++ b/cheminfoTypes.test-d.ts
@@ -1,6 +1,11 @@
 import { pino } from 'pino';
 import { expectAssignable } from 'tsd';
 
-import type { Logger } from '.';
+import type { Logger, DataXY } from '.';
 
 expectAssignable<Logger>(pino());
+
+expectAssignable<DataXY>({
+  x: new Float32Array(),
+  y: new Float32Array(),
+});

--- a/src/core/DataXY.d.ts
+++ b/src/core/DataXY.d.ts
@@ -1,12 +1,12 @@
-import { DoubleArray } from './DoubleArray';
+import { NumberArray } from './NumberArray';
 
-export interface DataXY<DataType extends DoubleArray = DoubleArray> {
+export interface DataXY<DataType extends NumberArray = NumberArray> {
   /**
-   * Array of numbers on x axis
+   * Array of numbers on x-axis
    */
   x: DataType;
   /**
-   * Array of numbers on y axis
+   * Array of numbers on y-axis
    */
   y: DataType;
 }


### PR DESCRIPTION
It's a generic enough type that we shouldn't restrict it too much.

Refs: https://github.com/mljs/spectra-processing/pull/224
